### PR TITLE
Start Deprecation of Inject Scope

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -17,6 +17,15 @@
         "doc",
         "test"
       ]
+    },
+    {
+      "login": "mqklin",
+      "name": "Maksim",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/9456433?v=4",
+      "profile": "https://github.com/mqklin",
+      "contributions": [
+        "bug"
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -7,34 +7,32 @@
 [![codecov](https://codecov.io/gh/kwelch/babel-plugin-captains-log/branch/master/graph/badge.svg?style=flat-square)](https://codecov.io/gh/kwelch/babel-plugin-captains-log)
 
 [![MIT License](https://img.shields.io/npm/l/kwelch.svg?style=flat-square)](http://opensource.org/licenses/MIT)
-[![Roadmap](https://img.shields.io/badge/%F0%9F%93%94-roadmap-CD9523.svg?style=flat-square)]([roadmap])
-[![All Contributors](https://img.shields.io/badge/all_contributors-1-orange.svg?style=flat-square)](#contributors)
+[![All Contributors](https://img.shields.io/badge/all_contributors-2-orange.svg?style=flat-square)](#contributors)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg?style=flat-square)](https://github.com/semantic-release/semantic-release)
 
 [![Watch on GitHub](https://img.shields.io/github/watchers/kwelch/babel-plugin-captains-log.svg?style=social)](https://github.com/kwelch/babel-plugin-captains-log/watchers)
 [![Star on GitHub](https://img.shields.io/github/stars/kwelch/babel-plugin-captains-log.svg?style=social)](https://github.com/kwelch/babel-plugin-captains-log/stargazers)
 [![Tweet](https://img.shields.io/twitter/url/https/github.com/kwelch/babel-plugin-captains-log.svg?style=social)](https://twitter.com/intent/tweet?text=Check%20out%20babel-plugin-captains-log!%20https://github.com/kwelch/babel-plugin-captains-log%20%F0%9F%91%8D)
-[![Join the chat at https://gitter.im/babel-plugin-captains-log/Lobby](https://badges.gitter.im/babel-plugin-captains-log/Lobby.svg?style=flat-square)](https://gitter.im/babel-plugin-captains-log/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 ## Usage
 
 `babel-plugin-captains-log` injects helpful details into console statements.
 
 Default bahavior:
-- Prepend console statement scope
+- prepend console statement file & location
 - add inject variable name into console statements
 
 **Transforms**
 ```diff
 function add(a, b) {
 -  console.log(a, b);
-+  console.log("simple.js(2:2)", "add:", "a", a, "b", b);
++  console.log("simple.js(2:2)", "a", a, "b", b);
   return a + b;
 }
 
 const subtract = (a, b) => {
 -  console.log(a, b);
-+  console.info("simple.js(7:2)", "subtract:", "a", a, "b", b);
++  console.info("simple.js(7:2)", "a", a, "b", b);
   return a - b;
 };
 ```
@@ -108,19 +106,6 @@ Flags are values set for all methods and are used to turn that feature on or off
 }
 ```
 
-#### Inject Scope
-**Default**: `true`
-
-```
-{
-  plugins: [
-    ["captains-log", {
-      "injectScope": true
-    }]
-  ]
-}
-```
-
 #### Inject File Name
 **Default**: `true`
 
@@ -134,9 +119,20 @@ Flags are values set for all methods and are used to turn that feature on or off
 }
 ```
 
-## Roadmap
+#### Inject Scope _(Experimental)_
+_This has a few issues with other plugins particularly react-hot-loader, as it changes method names. Also, it was written for recursion which adds too much noise to the console statement which is against this libraries purpose_
 
-- [ ] Add ability to timestamp console statements
+**Default**: `false`
+
+```
+{
+  plugins: [
+    ["captains-log", {
+      "injectScope": true
+    }]
+  ]
+}
+```
 
 ## License
 
@@ -147,8 +143,8 @@ MIT
 Thanks goes to these wonderful people ([emoji key](https://github.com/kentcdodds/all-contributors#emoji-key)):
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
-| [<img src="https://avatars0.githubusercontent.com/u/1295580?v=3" width="100px;"/><br /><sub>Kyle Welch</sub>](http://www.krwelch.com)<br />[💻](https://github.com/kwelch/babel-plugin-captains-log/commits?author=kwelch "Code") [📖](https://github.com/kwelch/babel-plugin-captains-log/commits?author=kwelch "Documentation") [⚠️](https://github.com/kwelch/babel-plugin-captains-log/commits?author=kwelch "Tests") |
-| :---: |
+| [<img src="https://avatars0.githubusercontent.com/u/1295580?v=3" width="100px;"/><br /><sub>Kyle Welch</sub>](http://www.krwelch.com)<br />[💻](https://github.com/kwelch/babel-plugin-captains-log/commits?author=kwelch "Code") [📖](https://github.com/kwelch/babel-plugin-captains-log/commits?author=kwelch "Documentation") [⚠️](https://github.com/kwelch/babel-plugin-captains-log/commits?author=kwelch "Tests") | [<img src="https://avatars1.githubusercontent.com/u/9456433?v=4" width="100px;"/><br /><sub>Maksim</sub>](https://github.com/mqklin)<br />[🐛](https://github.com/kwelch/babel-plugin-captains-log/issues?q=author%3Amqklin "Bug reports") |
+| :---: | :---: |
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/kentcdodds/all-contributors) specification. Contributions of any kind welcome!

--- a/src/__snapshots__/index.spec.js.snap
+++ b/src/__snapshots__/index.spec.js.snap
@@ -20,7 +20,7 @@ function add(a, b) {
       ↓ ↓ ↓ ↓ ↓ ↓
 
 function add(a, b) {
-  console.log(\\"unknown(2:2)\\", \\"add:\\", \\"a\\", a, \\"b\\", b);
+  console.log(\\"unknown(2:2)\\", \\"a\\", a, \\"b\\", b);
   return a + b;
 }
 "
@@ -36,7 +36,7 @@ const subtract = (a, b) => {
       ↓ ↓ ↓ ↓ ↓ ↓
 
 const subtract = (a, b) => {
-  console.info(\\"unknown(2:2)\\", \\"subtract:\\", \\"a\\", a, \\"b\\", b);
+  console.info(\\"unknown(2:2)\\", \\"a\\", a, \\"b\\", b);
   return a - b;
 };
 "
@@ -53,7 +53,7 @@ multiple = () => {
 
 let multiply;
 multiple = () => {
-  console.log(\\"unknown(3:2)\\", \\"multiple:\\", \\"3\\");
+  console.log(\\"unknown(3:2)\\", \\"3\\");
 };
 "
 `;
@@ -69,7 +69,7 @@ divide = function() {
 
 let divide;
 divide = function () {
-  console.log(\\"unknown(3:2)\\", \\"divide:\\", \\"4\\");
+  console.log(\\"unknown(3:2)\\", \\"4\\");
 };
 "
 `;
@@ -83,7 +83,7 @@ const power = function pow() {
       ↓ ↓ ↓ ↓ ↓ ↓
 
 const power = function pow() {
-  console.log(\\"unknown(2:2)\\", \\"power:\\", 5);
+  console.log(\\"unknown(2:2)\\", 5);
 };
 "
 `;
@@ -106,13 +106,13 @@ const obj = {
 
 const obj = {
   method1: function () {
-    console.log(\\"unknown(3:4)\\", \\"obj.method1:\\", 6);
+    console.log(\\"unknown(3:4)\\", 6);
   },
   method2: () => {
-    console.log(\\"unknown(6:4)\\", \\"obj.method2:\\", 7);
+    console.log(\\"unknown(6:4)\\", 7);
   },
   method3() {
-    console.log(\\"unknown(9:4)\\", \\"obj.method3:\\", 8);
+    console.log(\\"unknown(9:4)\\", 8);
   }
 };
 "
@@ -140,16 +140,16 @@ const Component = () => {
 
 const Component = () => {
   const privateMethod = () => {
-    console.log(\\"unknown(3:4)\\", \\"Component.privateMethod:\\", 1);
+    console.log(\\"unknown(3:4)\\", 1);
   };
   return class HighOrderComponent {
     showList() {
       arr.map(i => {
-        console.log(\\"unknown(8:8)\\", \\"Component.HighOrderComponent.showList:\\", \\"i\\", i);
+        console.log(\\"unknown(8:8)\\", \\"i\\", i);
       });
     }
     render() {
-      console.log(\\"unknown(12:6)\\", \\"Component.HighOrderComponent.render:\\", 2);
+      console.log(\\"unknown(12:6)\\", 2);
     }
   };
 };
@@ -168,7 +168,7 @@ class ToDoComponent {
 
 class ToDoComponent {
   render() {
-    console.log(\\"unknown(3:4)\\", \\"ToDoComponent.render:\\", this.props);
+    console.log(\\"unknown(3:4)\\", this.props);
   }
 }
 "
@@ -205,7 +205,7 @@ function logAll() {
   console.assert(1 === 1);
   console.clear();
   console.count(\\"count\\");
-  console.debug(\\"unknown(5:2)\\", \\"logAll:\\", \\"debug\\");
+  console.debug(\\"unknown(5:2)\\", \\"debug\\");
   console.dir(obj);
   console.error(\\"error\\");
   console.exception(\\"exception\\");
@@ -213,8 +213,8 @@ function logAll() {
   console.groupEnd(\\"group\\");
   console.groupCollapsed(\\"groupCollapsed\\");
   console.groupEnd(\\"groupCollapsed\\");
-  console.info(\\"unknown(13:2)\\", \\"logAll:\\", \\"info\\");
-  console.log(\\"unknown(14:2)\\", \\"logAll:\\", \\"log\\");
+  console.info(\\"unknown(13:2)\\", \\"info\\");
+  console.log(\\"unknown(14:2)\\", \\"log\\");
   console.profile(\\"profile\\");
   console.profileEnd(\\"profile\\");
   console.table([\\"table\\"]);

--- a/src/utils/__snapshots__/pluginOptions.spec.js.snap
+++ b/src/utils/__snapshots__/pluginOptions.spec.js.snap
@@ -4,7 +4,7 @@ exports[`buildOptions should allow methods to be changed 1`] = `
 Object {
   "debug": Object {
     "injectFileName": true,
-    "injectScope": true,
+    "injectScope": false,
     "injectVariableName": true,
   },
 }
@@ -14,32 +14,32 @@ exports[`buildOptions should overwrite defaults 1`] = `
 Object {
   "debug": Object {
     "injectFileName": false,
-    "injectScope": true,
+    "injectScope": false,
     "injectVariableName": true,
   },
   "error": Object {
     "injectFileName": false,
-    "injectScope": true,
+    "injectScope": false,
     "injectVariableName": true,
   },
   "exception": Object {
     "injectFileName": false,
-    "injectScope": true,
+    "injectScope": false,
     "injectVariableName": true,
   },
   "info": Object {
     "injectFileName": false,
-    "injectScope": true,
+    "injectScope": false,
     "injectVariableName": true,
   },
   "log": Object {
     "injectFileName": false,
-    "injectScope": true,
+    "injectScope": false,
     "injectVariableName": true,
   },
   "warn": Object {
     "injectFileName": false,
-    "injectScope": true,
+    "injectScope": false,
     "injectVariableName": true,
   },
 }
@@ -49,32 +49,32 @@ exports[`buildOptions should return defaults for invalid args 1`] = `
 Object {
   "debug": Object {
     "injectFileName": true,
-    "injectScope": true,
+    "injectScope": false,
     "injectVariableName": true,
   },
   "error": Object {
     "injectFileName": true,
-    "injectScope": true,
+    "injectScope": false,
     "injectVariableName": true,
   },
   "exception": Object {
     "injectFileName": true,
-    "injectScope": true,
+    "injectScope": false,
     "injectVariableName": true,
   },
   "info": Object {
     "injectFileName": true,
-    "injectScope": true,
+    "injectScope": false,
     "injectVariableName": true,
   },
   "log": Object {
     "injectFileName": true,
-    "injectScope": true,
+    "injectScope": false,
     "injectVariableName": true,
   },
   "warn": Object {
     "injectFileName": true,
-    "injectScope": true,
+    "injectScope": false,
     "injectVariableName": true,
   },
 }
@@ -84,32 +84,32 @@ exports[`buildOptions should return defaults for invalid args 2`] = `
 Object {
   "debug": Object {
     "injectFileName": true,
-    "injectScope": true,
+    "injectScope": false,
     "injectVariableName": true,
   },
   "error": Object {
     "injectFileName": true,
-    "injectScope": true,
+    "injectScope": false,
     "injectVariableName": true,
   },
   "exception": Object {
     "injectFileName": true,
-    "injectScope": true,
+    "injectScope": false,
     "injectVariableName": true,
   },
   "info": Object {
     "injectFileName": true,
-    "injectScope": true,
+    "injectScope": false,
     "injectVariableName": true,
   },
   "log": Object {
     "injectFileName": true,
-    "injectScope": true,
+    "injectScope": false,
     "injectVariableName": true,
   },
   "warn": Object {
     "injectFileName": true,
-    "injectScope": true,
+    "injectScope": false,
     "injectVariableName": true,
   },
 }
@@ -119,32 +119,32 @@ exports[`buildOptions should return defaults for invalid args 3`] = `
 Object {
   "debug": Object {
     "injectFileName": true,
-    "injectScope": true,
+    "injectScope": false,
     "injectVariableName": true,
   },
   "error": Object {
     "injectFileName": true,
-    "injectScope": true,
+    "injectScope": false,
     "injectVariableName": true,
   },
   "exception": Object {
     "injectFileName": true,
-    "injectScope": true,
+    "injectScope": false,
     "injectVariableName": true,
   },
   "info": Object {
     "injectFileName": true,
-    "injectScope": true,
+    "injectScope": false,
     "injectVariableName": true,
   },
   "log": Object {
     "injectFileName": true,
-    "injectScope": true,
+    "injectScope": false,
     "injectVariableName": true,
   },
   "warn": Object {
     "injectFileName": true,
-    "injectScope": true,
+    "injectScope": false,
     "injectVariableName": true,
   },
 }
@@ -154,32 +154,32 @@ exports[`buildOptions should return defaults for invalid args 4`] = `
 Object {
   "debug": Object {
     "injectFileName": true,
-    "injectScope": true,
+    "injectScope": false,
     "injectVariableName": true,
   },
   "error": Object {
     "injectFileName": true,
-    "injectScope": true,
+    "injectScope": false,
     "injectVariableName": true,
   },
   "exception": Object {
     "injectFileName": true,
-    "injectScope": true,
+    "injectScope": false,
     "injectVariableName": true,
   },
   "info": Object {
     "injectFileName": true,
-    "injectScope": true,
+    "injectScope": false,
     "injectVariableName": true,
   },
   "log": Object {
     "injectFileName": true,
-    "injectScope": true,
+    "injectScope": false,
     "injectVariableName": true,
   },
   "warn": Object {
     "injectFileName": true,
-    "injectScope": true,
+    "injectScope": false,
     "injectVariableName": true,
   },
 }

--- a/src/utils/pluginOptions.js
+++ b/src/utils/pluginOptions.js
@@ -1,5 +1,5 @@
 const defaultSettings = {
-  injectScope: true,
+  injectScope: false,
   injectVariableName: true,
   injectFileName: true,
 };


### PR DESCRIPTION
scope conceptually is a good idea, but has too many variations. I want to find a good way to support it, potentially by capping the depth. This still runs into issues with other plugins.

This can still be turned on via a flag. Please open an issue if you wish to have this back by default.